### PR TITLE
t/* - deal with YAML security change, and fix validation error test

### DIFF
--- a/t/22-round-tripping.t
+++ b/t/22-round-tripping.t
@@ -16,6 +16,7 @@ use Octothorpe;
 use XMLTests;
 use XML::Compare;
 use YAML;
+$YAML::LoadBlessed = 1;
 
 getopt;
 

--- a/t/24-parse-methods.t
+++ b/t/24-parse-methods.t
@@ -24,7 +24,7 @@ ok($valid_foo, "parse_fh(\*FOO)");
     eval {Octothorpe->parse_fh( 'blah' )};
     my $error = $@;
     ok( ($error =~ qr{Parameter #1 \("blah"\) to PRANG::Graph::parse_fh did not pass the 'checking type constraint for GlobRef' callback})
-    ||  ($error =~ qr{Parameter #1 does not pass the type constraint because: Validation failed for 'GlobRef' with value "blah"}) );
+    ||  ($error =~ qr{Parameter #1 does not pass the type constraint because: Validation failed for 'GlobRef' with value "?blah"?}) ) or diag "'$error'";
 }
 
 my $parser = XML::LibXML->new;

--- a/t/XMLTests.pm
+++ b/t/XMLTests.pm
@@ -7,7 +7,7 @@ use File::Find;
 use FindBin qw($Bin);
 use strict;
 use YAML qw(Load Dump);
-
+$YAML::LoadBlessed = 1;
 our $grep;
 getopt_lenient( "test-grep|t=s" => \$grep );
 


### PR DESCRIPTION
Currently PRANG fails on 5.37.8, because YAML was updated to be more secure, and because the validation error message no longer quotes the parameter name. This patch fixes both.